### PR TITLE
Fixed Docker Volume in new Docker Compose Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - ./config.yml:/app/data/config.yml
+      - ./mafl/:/app/data/
 ```
 
 ### Node

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - ./config.yml:/app/data/config.yml
+      - ./mafl:/app/data
 ```
 :::
 

--- a/docs/ru/guide/getting-started.md
+++ b/docs/ru/guide/getting-started.md
@@ -18,7 +18,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - ./config.yml:/app/data/config.yml
+      - ./mafl:/app/data
 ```
 :::
 


### PR DESCRIPTION
Thank you for building this project, it fits my use case perfectly while being minimal and sleek. 😊

While deploying as in your docs I found this problem with the Docker Volumes.
I remember that back then you could map files as Volumes, but in the current version you should map only folders.

So nobody gets miss leaded into using your/our software I decided to fork and PR.


Great project, keep going.
Cheers 🤜