### PR TITLE
fix: service icon overflow

### DIFF
--- a/src/components/service/base/Icon.vue
+++ b/src/components/service/base/Icon.vue
@@ -16,7 +16,7 @@ const wrapClasses = computed(() => ({
   'bg-fg/5 dark:bg-fg/10': props?.wrap && !props?.background,
   'p-2': props?.wrap,
   [iconClasses]: true,
-  'border border-fg/10 dark:border-fg/15 rounded-2xl': true,
+  'border border-fg/10 dark:border-fg/15 rounded-2xl overflow-hidden': true,
 }))
 
 const wrapStyles = computed(() => ({


### PR DESCRIPTION
Flag rendered by `IpApiService` overlaps icon container, which seems to be a bug.

This small one-line PR fixes that issue.

## Before
<img width="235" alt="before" src="https://github.com/user-attachments/assets/4129456f-4cc1-4be2-b667-8b93736eb4ae" />

## After
<img width="235" alt="after" src="https://github.com/user-attachments/assets/1111c6c8-24a4-4229-a0cd-b5be5ef6050c" />
