### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,8 +9,6 @@ Depending on your preferences and needs, you can refer to both `hywax/mafl` and 
 
 ::: code-group
 ```yaml [docker-compose.yml]
-version: '3.8'
-
 services:
   mafl:
     container_name: mafl # change as needed


### PR DESCRIPTION
Removed docker compose version as it is now obsolete: https://docs.docker.com/reference/compose-file/version-and-name/