### PR TITLE
Replace France (country) with French (langage) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Supported Languages:
 * 🇪🇸 **Spanish** - `es`
 * 🇸🇦 **Arabic** - `ar` (by [@mohmadhabib](https://github.com/mohmadhabib))
 * 🇵🇱 **Polish** - `pl` (by [@UberDudePL](https://github.com/UberDudePL))
-* 🇫🇷 **France** - `fr` (by [@maxim31cote](https://github.com/maxim31cote))
+* 🇫🇷 **French** - `fr` (by [@maxim31cote](https://github.com/maxim31cote))
 * 🇩🇪 **German** - `de` (by [@gehno](https://github.com/gehno))
 * 🇬🇷 **Greek** - `gr` (by [@sthivaios](https://github.com/sthivaios))
 


### PR DESCRIPTION
For the other translations, the name of the langage is shown. For french, it was written « France » (the country, not the langage).