### PR TITLE
feat/fix: support .yaml extension for the config file.

### DIFF
--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -28,7 +28,7 @@ function determineService(items: DraftService[], tags: TagMap): Service[] {
   }))
 }
 
-export const configFileName = 'config.yml'
+export const configFileNames = ['config.yml', 'config.yaml']
 
 export function getDefaultConfig(): CompleteConfig {
   return {
@@ -68,7 +68,17 @@ export async function loadConfig(): Promise<CompleteConfig> {
   const storage = useStorage('data')
 
   try {
-    if (!await storage.hasItem(configFileName)) {
+    let configFileName: string | null = null
+    
+    // Check for both config file extensions
+    for (const fileName of configFileNames) {
+      if (await storage.hasItem(fileName)) {
+        configFileName = fileName
+        break
+      }
+    }
+    
+    if (!configFileName) {
       throw new Error('Config not found')
     }
 

--- a/templates/unraid.xml
+++ b/templates/unraid.xml
@@ -17,7 +17,7 @@
     <TemplateURL>false</TemplateURL>
     <Icon>https://mafl.hywax.space/logotype.svg</Icon>
     <Config Name="WebUI Port" Target="3000" Default="3000" Mode="tcp" Description="Web UI Port" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
-    <Config Name="Config" Target="/app/data/config.yml" Default="/mnt/user/appdata/mafl/config.yaml" Mode="ro" Description="" Type="Path" Display="always" Required="true" Mask="false"/>
+    <Config Name="Config" Target="/app/data/config.yml" Default="/mnt/user/appdata/mafl/config.yml" Mode="ro" Description="" Type="Path" Display="always" Required="true" Mask="false"/>
     <Config Name="Local Icons" Target="/app/public/favicons" Default="/mnt/user/appdata/mafl/favicons" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false"/>
     <Config Name="Favicon Icons" Target="/app/public/icons" Default="/mnt/user/appdata/mafl/icons" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
@hywax 

After a little bit of pain setting mafl today I thought I would propose this PR.
I took me a little bit of digging to find out that I named my config `config.yaml` instead of `config.yml`.

Since `.yaml` is the official extension for yaml file, we should probably support it :)

# Goal

Support `.yaml` extension (as well as `.yml`) for the config
`.yaml` is the official extension, but since all the docs points to `.yml` I don't think we should enforce it as the default or only option. But supporting `config.yaml` seems important.

Besides, the unraid is currently pointing to a `config.yaml` which would result in an error!

# How to test

There isn't a test suite as far as I can tell (happy to set one up for you) so I didn't put any tests - only manually checked the code.

To do, run this branch locally with a `config.yaml` and ensure it works as expected!


Thanks for the good work, I love this project.
