### PR TITLE
fix: preserve aspect ratio of non-square service icons

### DIFF
--- a/src/components/service/base/Icon.vue
+++ b/src/components/service/base/Icon.vue
@@ -10,7 +10,7 @@ import type { ServiceIcon } from '~/types'
 
 const props = defineProps<ServiceIcon>()
 
-const iconClasses = 'block h-full w-full'
+const iconClasses = 'block h-full w-full object-contain'
 
 const wrapClasses = computed(() => ({
   'bg-fg/5 dark:bg-fg/10': props?.wrap && !props?.background,


### PR DESCRIPTION
## Problem

Service icons provided via `icon.url` are rendered with `h-full w-full` and no `object-fit`, so non-square images get stretched to the square icon box and look distorted.

## Fix

Add `object-contain` to the icon classes — non-square images are now scaled to fit and centered, square icons are unaffected.

One-line change in `src/components/service/base/Icon.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)