### PR TITLE
fix: resolve local icon paths from root

### DIFF
--- a/src/components/service/base/Icon.vue
+++ b/src/components/service/base/Icon.vue
@@ -1,16 +1,19 @@
 <template>
   <div :class="wrapClasses" :style="wrapStyles">
     <Icon v-if="props?.name" :name="props.name" :class="iconClasses" />
-    <img v-else-if="props?.url" :src="props.url" alt="" :class="iconClasses">
+    <img v-else-if="iconUrl" :src="iconUrl" alt="" :class="iconClasses">
   </div>
 </template>
 
 <script setup lang="ts">
 import type { ServiceIcon } from '~/types'
+import { normalizeIconUrl } from '~/utils/icon'
 
 const props = defineProps<ServiceIcon>()
 
 const iconClasses = 'block h-full w-full'
+
+const iconUrl = computed(() => normalizeIconUrl(props?.url))
 
 const wrapClasses = computed(() => ({
   'bg-fg/5 dark:bg-fg/10': props?.wrap && !props?.background,

--- a/src/utils/icon.ts
+++ b/src/utils/icon.ts
@@ -1,0 +1,9 @@
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+\-.]*:/i
+
+export function normalizeIconUrl(url?: string): string | undefined {
+  if (!url || url.startsWith('/') || url.startsWith('#') || ABSOLUTE_URL_PATTERN.test(url)) {
+    return url
+  }
+
+  return `/${url.replace(/^\.?\//, '')}`
+}


### PR DESCRIPTION
## Summary
- normalize relative local icon URLs to root-relative paths
- preserve absolute, protocol-relative, data, and fragment URLs

This keeps documented local icon paths such as `icons/example.svg` working when the dashboard is opened from a nested route.

## Testing
- 7 URL normalization behavior checks
- `git diff --check`